### PR TITLE
pre-commit whitespace hooks: exclude patch files

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -5,10 +5,17 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
-        exclude: ^secrets/|environments/.*/secrets\.cfg
+        exclude: |
+          (?x)^(
+            secrets/|environments/.*/secrets\.cfg|
+            .*\.patch
+          )$
     -   id: end-of-file-fixer
-        # These are non-anchored regular rexpressions
-        exclude: ^secrets/|environments/.*/secrets\.cfg
+        exclude: |
+          (?x)^(
+            secrets/|environments/.*/secrets\.cfg|
+            .*\.patch
+          )$
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: check-json

--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -5,10 +5,10 @@ repos:
     rev: v3.2.0
     hooks:
     -   id: trailing-whitespace
-        exclude: "^secrets/|environments/.*/secrets.cfg"
+        exclude: ^secrets/|environments/.*/secrets\.cfg
     -   id: end-of-file-fixer
         # These are non-anchored regular rexpressions
-        exclude: "^secrets/|environments/.*/secrets.cfg"
+        exclude: ^secrets/|environments/.*/secrets\.cfg
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: check-json


### PR DESCRIPTION
Patch files are usually generated automatically and might include
trailing whitespace just due to their generation process. Changing them
always includes the risk of them not applying anymore afterwards.

This mainly affects our fc-nixos repo and can be applied to that after review and merging.

While implementing this patch file exclusion, I also discovered that existing exclude directives were over-matching and fixed this.