### PR TITLE
Improve exclude rules for secrets

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     -   id: trailing-whitespace
         exclude: |
           (?x)^(
-            secrets/|environments/.*/secrets\.cfg|
+            secrets/|environments/.*/secret.*|
             .*\.patch
           )$
     -   id: end-of-file-fixer
         exclude: |
           (?x)^(
-            environments/.*/secrets\.cfg|
+            environments/.*/secret.*|
             .*\.patch
           )$
     -   id: check-yaml


### PR DESCRIPTION
When using the files-feature of secrets

```
├── production
│   ├── environment.cfg
│   ├── secret-my_ssl_crt.pem
│   ├── secret-my_ssl_key.pem
```

the secrets were not correct detected and the lineendings as well as the whitespaces hook were trying to "improve" them. 
