### PR TITLE
[FC-33216] ignore secret files

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -7,6 +7,8 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
+    -   id: detect-private-key
+    -   id: check-added-large-files
     -   id: trailing-whitespace
         exclude: |
           (?x)^(
@@ -20,11 +22,29 @@ repos:
             .*\.patch
           )$
     -   id: check-yaml
-    -   id: check-added-large-files
+        exclude: |
+          (?x)^(
+            environments/.*/secret.*|
+            .*\.patch
+          )$
     -   id: check-json
+        exclude: |
+          (?x)^(
+            environments/.*/secret.*|
+            .*\.patch
+          )$
     -   id: check-xml
+        exclude: |
+          (?x)^(
+            environments/.*/secret.*|
+            .*\.patch
+          )$
     -   id: check-toml
-    -   id: detect-private-key
+        exclude: |
+          (?x)^(
+            environments/.*/secret.*|
+            .*\.patch
+          )$
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0


### PR DESCRIPTION
Secret files should not be checked by any of the format checkers since they are encrypted.

This change will be redundant after the batou 2.4 release with the introduction of secret file extensions