### PR TITLE
Allow ruff to fix obvious things like format strings without any plac…

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -63,4 +63,4 @@ repos:
   hooks:
     - id: ruff
       # ignore "line too long" [E501] and "imported but unused" [F401] (required for some batou functionality)
-      args: [ "--ignore", "E501", "--ignore", "F401" ]
+      args: [ "--ignore", "E501", "--ignore", "F401", "--fix"]


### PR DESCRIPTION
…eholders

Something like 

```
Purge(f"/etc/local/nixos/enqueue_consume_2.nix")
```
-> 

```
Purge("/etc/local/nixos/enqueue_consume_2.nix")
```
